### PR TITLE
Refactor advisor flow; add time-series CV, guardrails, and tests

### DIFF
--- a/indicators/__init__.py
+++ b/indicators/__init__.py
@@ -1,0 +1,1 @@
+"""Indicators package."""

--- a/main.py
+++ b/main.py
@@ -1,118 +1,174 @@
-import pandas as pd
-import numpy as np
+from __future__ import annotations
 
-# Fetch historical stock price data based on the user's input
+import time
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+import pandas as pd
 import yfinance as yf
 from pandas_datareader import data as web
+from sklearn.linear_model import LinearRegression
+from sklearn.model_selection import TimeSeriesSplit
+
+from strategy.stock_strategy import recommend_action
 
 
 def process_data(data: pd.DataFrame) -> pd.DataFrame:
     """Sort by date so the last row reflects the latest close."""
-    data.reset_index(inplace=True)
-    data.sort_values("Date", inplace=True)
-    data.reset_index(drop=True, inplace=True)
-    return data
+    processed = data.reset_index().sort_values("Date").reset_index(drop=True)
+    return processed
 
-def get_historical_data(symbol):
+
+def get_historical_data(symbol: str) -> Tuple[Optional[pd.DataFrame], Optional[str]]:
     """Fetch historical stock data and return the DataFrame and data source."""
     print(f"Fetching historical data for {symbol}...")
     print("----------------------------------------------------------------")
-
-    data_source = None
 
     # First try Yahoo Finance via yfinance
     try:
         stock = yf.Ticker(symbol)
         data = stock.history(period="max")
         if not data.empty:
-            data_source = "Yahoo Finance"
-            print(f"Successfully fetched historical data for {symbol} from {data_source}")
+            print(f"Successfully fetched historical data for {symbol} from Yahoo Finance")
             print("----------------------------------------------------------------")
-            data = process_data(data)
-            return data, data_source
-        else:
-            print("No data returned from Yahoo Finance. Trying Stooq...")
-    except Exception as e:
-        print(f"Yahoo Finance retrieval failed: {e}. Trying Stooq...")
+            return process_data(data), "Yahoo Finance"
+
+        print("No data returned from Yahoo Finance. Trying Stooq...")
+    except Exception as exc:
+        print(f"Yahoo Finance retrieval failed: {exc}. Trying Stooq...")
 
     # Fallback to Stooq using pandas_datareader
     try:
-        data = web.DataReader(symbol, 'stooq')
+        data = web.DataReader(symbol, "stooq")
         if not data.empty:
-            data_source = "Stooq"
-            print(f"Successfully fetched historical data for {symbol} from {data_source}")
+            print(f"Successfully fetched historical data for {symbol} from Stooq")
             print("----------------------------------------------------------------")
-            data = process_data(data)
-            return data, data_source
-    except Exception as e:
-        print(f"Stooq retrieval failed: {e}")
+            return process_data(data), "Stooq"
+    except Exception as exc:
+        print(f"Stooq retrieval failed: {exc}")
 
     print(f"Historical data for {symbol} not found.")
-    return None, data_source
-# Ask the user for a stock symbol
-user_symbol = input("Enter the stock symbol (e.g., AAPL): ").upper()
-print("----------------------------------------------------------------")
+    return None, None
 
-# Fetch historical data for the user-provided symbol
-data, data_source = get_historical_data(user_symbol)
 
-if data is not None:
-    # Display the latest close price and data source
-    current_price = round(float(data['Close'].iloc[-1]), 2)
+def build_features(data: pd.DataFrame) -> pd.DataFrame:
+    """Create time-based numeric feature used by the baseline regression model."""
+    features = data.copy()
+    features["Date_Num"] = (features["Date"] - features["Date"].min()).dt.days
+    return features
+
+
+def validate_training_data(data: pd.DataFrame, min_rows: int = 30) -> None:
+    """Validate minimum history required for model training."""
+    if len(data) < min_rows:
+        raise ValueError(
+            f"Not enough historical rows for forecasting. Found {len(data)}, need at least {min_rows}."
+        )
+
+
+def train_forecasting_model(data: pd.DataFrame, n_splits: int = 5) -> Tuple[LinearRegression, float]:
+    """Train baseline linear regression with time-series-aware cross validation."""
+    validate_training_data(data)
+    features = build_features(data)
+    X = features[["Date_Num"]].values
+    y = features["Close"].values
+
+    # TimeSeriesSplit preserves chronological order and avoids leakage.
+    split_count = max(2, min(n_splits, len(features) - 1))
+    tscv = TimeSeriesSplit(n_splits=split_count)
+
+    scores = []
+    for train_idx, test_idx in tscv.split(X):
+        fold_model = LinearRegression()
+        fold_model.fit(X[train_idx], y[train_idx])
+        scores.append(fold_model.score(X[test_idx], y[test_idx]))
+
+    model = LinearRegression()
+    model.fit(X, y)
+
+    return model, float(np.mean(scores)) if scores else float("nan")
+
+
+def predict_future_prices(model: LinearRegression, data: pd.DataFrame) -> Dict[str, float]:
+    """Predict price for tomorrow, next week, and next month."""
+    max_day = int(data["Date_Num"].max())
+    day_offsets = {
+        "tomorrow": max_day + 1,
+        "next_week": max_day + 7,
+        "next_month": max_day + 30,
+    }
+    predictions = {
+        label: round(float(model.predict(np.array([[day]]))[0]), 2)
+        for label, day in day_offsets.items()
+    }
+    return predictions
+
+
+def run_advisor_for_symbol(symbol: str) -> Optional[Dict[str, object]]:
+    """Run the stock advisor flow for one symbol and return structured output."""
+    data, data_source = get_historical_data(symbol)
+    if data is None or data_source is None:
+        return None
+
+    current_price = round(float(data["Close"].iloc[-1]), 2)
     print(f"Current price from {data_source}: {current_price}")
     print("----------------------------------------------------------------")
 
-    # Prepare the data for machine learning
-    data['Date_Num'] = (data['Date'] - data['Date'].min()).dt.days  # Convert date to numerical format
-    X = data[['Date_Num']].values
-    y = data['Close'].values
-    
-    from sklearn.model_selection import train_test_split
-
-    # Split the data into training and testing sets
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
-    
-    from sklearn.linear_model import LinearRegression
-
-    # Train a Linear Regression model
-    model = LinearRegression()
-    model.fit(X_train, y_train)
-    
-    # Predict stock prices for tomorrow, next week, and next month
-    tomorrow_date = data['Date_Num'].max() + 1
-    next_week_date = data['Date_Num'].max() + 7
-    next_month_date = data['Date_Num'].max() + 30
-    
-    price_tomorrow = round(model.predict(np.array([[tomorrow_date]]))[0], 2)
-    price_next_week = round(model.predict(np.array([[next_week_date]]))[0], 2)
-    price_next_month = round(model.predict(np.array([[next_month_date]]))[0], 2)
-    
-    from strategy.stock_strategy import recommend_action
-
-    # Calculate the recommendation for tomorrow, next week, and next month
-    action_tomorrow = recommend_action(data, price_tomorrow)
-    action_week = recommend_action(data, price_next_week)
-    action_next_month = recommend_action(data, price_next_month)
-    
-    import time
-
-    time.sleep(1)
-
-    # Output the recommendations for tomorrow
-    print(f"Price prediction for tomorrow: {price_tomorrow}")
-    print(f"Recommendation for {user_symbol} for tomorrow: {action_tomorrow}")
+    data = build_features(data)
+    model, cv_score = train_forecasting_model(data)
+    print(f"TimeSeries CV R^2 (mean): {round(cv_score, 4)}")
     print("----------------------------------------------------------------")
-    time.sleep(1)
 
-    # Output the recommendations for next week
-    print(f"Price prediction for next week: {price_next_week}")
-    print(f"Recommendation for {user_symbol} for the next week: {action_week}")
+    predictions = predict_future_prices(model, data)
+    recommendations = {
+        "tomorrow": recommend_action(data.copy(), predictions["tomorrow"]),
+        "next_week": recommend_action(data.copy(), predictions["next_week"]),
+        "next_month": recommend_action(data.copy(), predictions["next_month"]),
+    }
+
+    return {
+        "symbol": symbol,
+        "data_source": data_source,
+        "current_price": current_price,
+        "predictions": predictions,
+        "recommendations": recommendations,
+    }
+
+
+def print_report(result: Dict[str, object]) -> None:
+    symbol = str(result["symbol"])
+    predictions = result["predictions"]
+    recommendations = result["recommendations"]
+
+    time.sleep(1)
+    print(f"Price prediction for tomorrow: {predictions['tomorrow']}")
+    print(f"Recommendation for {symbol} for tomorrow: {recommendations['tomorrow']}")
     print("----------------------------------------------------------------")
-    time.sleep(1)
 
-    # Output the recommendations for next month
-    print(f"Price prediction for next month: {price_next_month}")
-    print(f"Recommendation for {user_symbol} for the next month: {action_next_month}")
+    time.sleep(1)
+    print(f"Price prediction for next week: {predictions['next_week']}")
+    print(f"Recommendation for {symbol} for the next week: {recommendations['next_week']}")
     print("----------------------------------------------------------------")
-    time.sleep(1)
 
+    time.sleep(1)
+    print(f"Price prediction for next month: {predictions['next_month']}")
+    print(f"Recommendation for {symbol} for the next month: {recommendations['next_month']}")
+    print("----------------------------------------------------------------")
+
+
+def main() -> None:
+    user_symbol = input("Enter the stock symbol (e.g., AAPL): ").upper()
+    print("----------------------------------------------------------------")
+
+    try:
+        result = run_advisor_for_symbol(user_symbol)
+    except ValueError as exc:
+        print(exc)
+        return
+
+    if result is not None:
+        print_report(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/strategy/__init__.py
+++ b/strategy/__init__.py
@@ -1,0 +1,1 @@
+"""Strategy package."""

--- a/strategy/stock_strategy.py
+++ b/strategy/stock_strategy.py
@@ -1,32 +1,70 @@
 # strategy/stock_strategy.py
 import pandas as pd
-from indicators.moving_averages import simple_moving_average, exponential_moving_average, macd, on_balance_volume, average_true_range
 
-def recommend_action(data, predicted_price):
+from indicators.moving_averages import (
+    average_true_range,
+    exponential_moving_average,
+    macd,
+    on_balance_volume,
+    simple_moving_average,
+)
+
+REQUIRED_COLUMNS = {"Close", "High", "Low", "Volume"}
+MIN_HISTORY_ROWS = 50
+
+
+def is_obv_and_atr_positive(data: pd.DataFrame) -> bool:
+    """Return True when momentum (OBV) and volatility (ATR) are positive."""
+    obv_latest = data["OBV"].iloc[-1]
+    atr_latest = data["ATR"].iloc[-1]
+
+    if pd.isna(obv_latest) or pd.isna(atr_latest):
+        return False
+
+    return bool(obv_latest > 0 and atr_latest > 0)
+
+
+def _is_data_sufficient(data: pd.DataFrame) -> bool:
+    """Validate required columns and enough rows for rolling indicators."""
+    if not REQUIRED_COLUMNS.issubset(data.columns):
+        return False
+
+    return len(data) >= MIN_HISTORY_ROWS
+
+
+def recommend_action(data: pd.DataFrame, predicted_price: float) -> str:
+    """Return a conservative Buy/Short action from trend + momentum signals."""
+    if not _is_data_sufficient(data):
+        return "Short"
+
     # Calculate moving averages
-    data['SMA_20'] = simple_moving_average(data, window=20)
-    data['SMA_50'] = simple_moving_average(data, window=50)
-    data['EMA_12'] = exponential_moving_average(data, span=12)
-    data['EMA_26'] = exponential_moving_average(data, span=26)
+    data["SMA_20"] = simple_moving_average(data, window=20)
+    data["SMA_50"] = simple_moving_average(data, window=50)
+    data["EMA_12"] = exponential_moving_average(data, span=12)
+    data["EMA_26"] = exponential_moving_average(data, span=26)
 
     # Calculate MACD and its signal line
-    data['MACD'], data['MACD_Signal'] = macd(data, span_fast=12, span_slow=26, span_signal=9)
+    data["MACD"], data["MACD_Signal"] = macd(
+        data, span_fast=12, span_slow=26, span_signal=9
+    )
 
     # Calculate On-Balance Volume
-    data['OBV'] = on_balance_volume(data)
+    data["OBV"] = on_balance_volume(data)
 
     # Calculate Average True Range
-    data['ATR'] = average_true_range(data, window=14)  # Assuming a 14-day window for ATR
+    data["ATR"] = average_true_range(data, window=14)
 
     # Convert last closing price to float
-    last_closing_price = float(data['Close'].iloc[-1])
+    last_closing_price = float(data["Close"].iloc[-1])
 
     # Comparison
-    if (predicted_price > last_closing_price and
-        data['SMA_20'].iloc[-1] > data['SMA_50'].iloc[-1] and
-        data['EMA_12'].iloc[-1] > data['EMA_26'].iloc[-1] and
-        data['MACD'].iloc[-1] > data['MACD_Signal'].iloc[-1] and
-        is_obv_and_atr_positive(data)):
+    if (
+        predicted_price > last_closing_price
+        and data["SMA_20"].iloc[-1] > data["SMA_50"].iloc[-1]
+        and data["EMA_12"].iloc[-1] > data["EMA_26"].iloc[-1]
+        and data["MACD"].iloc[-1] > data["MACD_Signal"].iloc[-1]
+        and is_obv_and_atr_positive(data)
+    ):
         return "Buy"
-    else:
-        return "Short"
+
+    return "Short"

--- a/tests/test_main_data_sources.py
+++ b/tests/test_main_data_sources.py
@@ -1,0 +1,69 @@
+import pandas as pd
+
+import main
+
+
+def _make_market_data() -> pd.DataFrame:
+    dates = pd.date_range("2024-01-01", periods=60, freq="D")
+    return pd.DataFrame(
+        {
+            "Date": dates,
+            "Close": [100 + i for i in range(60)],
+            "High": [101 + i for i in range(60)],
+            "Low": [99 + i for i in range(60)],
+            "Volume": [1000 + i for i in range(60)],
+        }
+    )
+
+
+def test_get_historical_data_falls_back_to_stooq_when_yahoo_empty(monkeypatch) -> None:
+    class DummyTicker:
+        def history(self, period: str) -> pd.DataFrame:
+            return pd.DataFrame()
+
+    monkeypatch.setattr(main.yf, "Ticker", lambda symbol: DummyTicker())
+    monkeypatch.setattr(main.web, "DataReader", lambda symbol, source: _make_market_data().set_index("Date"))
+
+    data, source = main.get_historical_data("AAPL")
+
+    assert source == "Stooq"
+    assert data is not None
+    assert data["Date"].is_monotonic_increasing
+
+
+def test_get_historical_data_uses_yahoo_when_available(monkeypatch) -> None:
+    class DummyTicker:
+        def history(self, period: str) -> pd.DataFrame:
+            return _make_market_data().set_index("Date")
+
+    monkeypatch.setattr(main.yf, "Ticker", lambda symbol: DummyTicker())
+
+    def _fail_if_called(symbol: str, source: str) -> pd.DataFrame:
+        raise AssertionError("Stooq should not be called when Yahoo data is available")
+
+    monkeypatch.setattr(main.web, "DataReader", _fail_if_called)
+
+    data, source = main.get_historical_data("AAPL")
+
+    assert source == "Yahoo Finance"
+    assert data is not None
+    assert data["Date"].is_monotonic_increasing
+
+
+def test_train_forecasting_model_rejects_short_history() -> None:
+    short_data = pd.DataFrame(
+        {
+            "Date": pd.date_range("2024-01-01", periods=5, freq="D"),
+            "Close": [100, 101, 102, 103, 104],
+            "High": [101, 102, 103, 104, 105],
+            "Low": [99, 100, 101, 102, 103],
+            "Volume": [1000, 1005, 1010, 1015, 1020],
+        }
+    )
+    short_data = main.build_features(short_data)
+
+    try:
+        main.train_forecasting_model(short_data)
+        assert False, "Expected ValueError for short history"
+    except ValueError as exc:
+        assert "Not enough historical rows" in str(exc)

--- a/tests/test_stock_strategy.py
+++ b/tests/test_stock_strategy.py
@@ -1,0 +1,55 @@
+import pandas as pd
+
+from strategy.stock_strategy import is_obv_and_atr_positive, recommend_action
+
+
+def _base_data(rows: int = 60) -> pd.DataFrame:
+    close = [100 + i for i in range(rows)]
+    volume = [1_000 + (i * 10) for i in range(rows)]
+    high = [c + 1 for c in close]
+    low = [c - 1 for c in close]
+    return pd.DataFrame(
+        {
+            "Close": close,
+            "High": high,
+            "Low": low,
+            "Volume": volume,
+        }
+    )
+
+
+def test_is_obv_and_atr_positive_true_for_positive_values() -> None:
+    data = pd.DataFrame({"OBV": [10, 20], "ATR": [0.5, 1.1]})
+
+    assert bool(is_obv_and_atr_positive(data)) is True
+
+
+def test_is_obv_and_atr_positive_false_for_nan_values() -> None:
+    data = pd.DataFrame({"OBV": [10, float("nan")], "ATR": [0.5, 1.1]})
+
+    assert bool(is_obv_and_atr_positive(data)) is False
+
+
+def test_recommend_action_returns_buy_for_bullish_inputs() -> None:
+    data = _base_data()
+
+    assert recommend_action(data, predicted_price=300.0) == "Buy"
+
+
+def test_recommend_action_returns_short_when_prediction_is_not_higher() -> None:
+    data = _base_data()
+
+    latest_close = float(data["Close"].iloc[-1])
+    assert recommend_action(data, predicted_price=latest_close - 5) == "Short"
+
+
+def test_recommend_action_returns_short_when_history_is_too_short() -> None:
+    data = _base_data(rows=20)
+
+    assert recommend_action(data, predicted_price=500.0) == "Short"
+
+
+def test_recommend_action_returns_short_when_required_columns_missing() -> None:
+    data = pd.DataFrame({"Close": [100, 101, 102]})
+
+    assert recommend_action(data, predicted_price=110.0) == "Short"


### PR DESCRIPTION
### Motivation
- Make the CLI script import-safe and testable by removing execution-at-import and exposing reusable functions for each step of the advisor flow. 
- Improve forecasting correctness by replacing random splits with time-series-aware validation to avoid temporal leakage. 
- Prevent runtime errors and misleading indicators by adding input validation and guardrails for short histories and missing OHLCV columns. 
- Ensure data-source behavior (Yahoo Finance then Stooq fallback) is stable and mockable for unit tests.

### Description
- Refactor `main.py` into import-safe, reusable functions including `process_data`, `get_historical_data`, `build_features`, `validate_training_data`, `train_forecasting_model` (uses `TimeSeriesSplit`), `predict_future_prices`, `run_advisor_for_symbol`, `print_report`, and `main` as the CLI entrypoint. 
- Replace the previous random `train_test_split` approach with time-series cross validation via `sklearn.model_selection.TimeSeriesSplit` and report mean fold R² before fitting the final `LinearRegression`. 
- Add training and strategy guardrails: `validate_training_data` raises `ValueError` for too-short histories and `strategy.stock_strategy` now checks `REQUIRED_COLUMNS` and `MIN_HISTORY_ROWS` before computing rolling indicators and returns a conservative `Short` when insufficient. 
- Add unit tests covering data-source fallback and Yahoo-first success with monkeypatch mocks, short-history rejection for training (`tests/test_main_data_sources.py`), and expanded strategy tests for OBV/ATR behavior and guardrail cases (`tests/test_stock_strategy.py`), and add minimal package `__init__.py` files.

### Testing
- Ran `python -m pytest -q` and all tests passed: `9 passed` with warnings. 
- Compiled modules with `python -m compileall main.py strategy indicators tests` and compilation completed successfully. 
- Commands executed in validation: `python -m pytest -q` and `python -m compileall main.py strategy indicators tests`, both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994dfe9813c83309187ba8d8eec51c2)