### PR TITLE
Restructure AI/agent instruction docs into layered policy and add research notes

### DIFF
--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -1,0 +1,28 @@
+# GitHub Agents Guidance
+
+This directory holds hosted-agent profile documents for GitHub workflows.
+
+## Design Goals
+- Keep one baseline policy source (`AGENTS.md`).
+- Keep profile docs role-specific and brief.
+- Avoid duplicated long policy blocks.
+
+## Suggested Layout
+- `.github/agents/README.md` (this index)
+- `.github/agents/reviewer.md` (optional)
+- `.github/agents/maintainer.md` (optional)
+- `.github/agents/triage.md` (optional)
+
+## Required Sections for Any Profile
+1. **Scope** (what the profile can and cannot do)
+2. **Inputs** (issues, PRs, files, commands)
+3. **Workflow** (ordered steps)
+4. **Validation** (required checks/commands)
+5. **Output Format** (how results are reported)
+6. **Safety Constraints** (secrets, destructive actions, claims)
+
+## Baseline Behavior for All Profiles
+- Follow `AGENTS.md` first.
+- Keep changes minimal and directly relevant.
+- Validate with `PYTHONPATH=. pytest -q` when code changes.
+- Preserve educational framing (no guaranteed financial outcomes).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,31 @@
+# GitHub Copilot Instructions (Repository)
+
+This file is optimized for Copilot context: concise, high-signal, and task-oriented.
+
+## Primary References
+1. `AGENTS.md` (operational rules and precedence)
+2. `AI_INSTRUCTIONS.md` (engineering quality standards)
+
+When conflicts appear, follow `AGENTS.md`.
+
+## Copilot Coding Rules
+- Make small, focused edits; avoid broad refactors.
+- Preserve data-source fallback behavior unless explicitly asked to change it.
+- Keep strategy logic deterministic and easy to review.
+- Validate empty/missing data before indicator/strategy calculations.
+- Do not introduce new dependencies unless necessary.
+
+## Python Rules
+- Follow PEP 8.
+- Prefer clear names and single-purpose functions.
+- Catch specific exceptions where practical.
+- Remove unused imports/code in touched files.
+
+## Testing Rules
+- Add/update tests for behavior changes.
+- Prefer deterministic tests (mocks/stubs over live network calls).
+- Validation command: `PYTHONPATH=. pytest -q`.
+
+## Documentation Rules
+- Update `README.md` when user-visible behavior or setup changes.
+- Keep generated docs concise and actionable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# AGENTS.md
+
+Guidance for autonomous coding agents working in this repository.
+
+## Scope
+This file applies to the entire repository tree rooted at this directory.
+
+## Mission
+Maintain a reliable, educational stock-advisor codebase with clear strategy logic,
+robust data-source handling, and dependable tests.
+
+## Instruction Hierarchy (Apply in this order)
+1. Direct user/developer/system instructions for the current task.
+2. This `AGENTS.md` (repo-wide operational contract).
+3. Runtime-specific files (for example, `.github/copilot-instructions.md`).
+4. Supplemental guidance (`AI_INSTRUCTIONS.md`, `SKILLS.md`, `.github/agents/*`).
+
+If guidance conflicts, follow the highest-priority item and call out the conflict in your summary.
+
+## Working Agreement
+1. Make the smallest safe change that solves the requested task.
+2. Keep strategy/indicator behavior explicit and testable.
+3. Prefer readability over cleverness.
+4. Do not perform unrelated cleanup unless requested.
+
+## Project Map
+- `main.py`: application entry point and data-source orchestration.
+- `indicators/`: technical indicator calculations.
+- `strategy/`: recommendation logic.
+- `tests/`: behavior and regression tests.
+
+## Implementation Rules
+### Code Quality
+- Follow PEP 8 and keep functions focused.
+- Add comments/docstrings only where they increase clarity.
+- Keep imports clean and remove dead code.
+
+### Data and Trading Logic
+- Preserve current data-source fallback behavior unless task requires changes.
+- Keep recommendations grounded in available indicator values.
+- Defensively handle empty/invalid data frames before calculations.
+
+### Dependency Policy
+- Avoid introducing new dependencies unless clearly necessary.
+- If adding a dependency, update `requirements.txt` and justify it in the PR.
+
+### Testing Policy
+- Run test suite for every code change.
+- Add or update tests whenever behavior changes.
+- Prefer deterministic tests; avoid network dependence in tests.
+
+### Documentation Policy
+- Update `README.md` if setup, behavior, or outputs change.
+- Keep docs concise and actionable.
+
+## Git and PR Standards
+- Use descriptive commit messages in imperative mood.
+- Include a PR summary with:
+  - change overview,
+  - rationale,
+  - validation commands/results,
+  - known limitations.
+
+## Safety and Compliance
+- Never commit secrets or credentials.
+- Treat output as educational, not financial advice.
+- Avoid claims of guaranteed investment outcomes.
+
+## Companion AI/Agent Files
+- `AI_INSTRUCTIONS.md`: cross-runtime AI engineering standards.
+- `.github/copilot-instructions.md`: GitHub Copilot/Copilot Chat behavior.
+- `.github/agents/README.md`: hosted-agent profile conventions.
+- `SKILLS.md`: conventions for introducing repository-local skills.
+- `docs/ai/RESEARCH_NOTES.md`: rationale and external guidance used for structure decisions.
+
+## Done Criteria
+A task is complete when:
+- Requested changes are implemented,
+- tests pass,
+- documentation is updated if needed,
+- diff is minimal and reviewable.

--- a/AI_INSTRUCTIONS.md
+++ b/AI_INSTRUCTIONS.md
@@ -1,0 +1,68 @@
+# AI Contributor Instructions
+
+This file defines engineering standards for AI-assisted changes in this repository.
+
+## Scope and Role
+- Applies to AI coding assistants across local tools, CI automation, and hosted coding agents.
+- Complements `AGENTS.md` (operational contract) and runtime-specific files.
+
+## Recommended Documentation Structure
+Use a layered model:
+1. **Operational contract**: `AGENTS.md` (what every agent must do).
+2. **Engineering standards**: this file (how changes should be implemented).
+3. **Runtime adapters**:
+   - `.github/copilot-instructions.md` for Copilot-specific behavior.
+   - `.github/agents/README.md` for hosted-agent profile layout.
+4. **Specialized extension policy**: `SKILLS.md` for future repo-local skills.
+
+## Core Principles
+- **Safety first:** preserve educational intent; avoid certainty language in financial contexts.
+- **Small, reviewable diffs:** prefer scoped changes.
+- **Test-backed changes:** behavior updates require validation.
+- **Determinism:** avoid flaky and network-dependent tests when possible.
+- **Transparency:** state assumptions, limits, and trade-offs.
+
+## Engineering Standards
+### Design
+- Keep indicator calculations and strategy decisions separated.
+- Keep data-fetch/IO boundaries explicit.
+- Preserve backward-compatible CLI behavior unless requested otherwise.
+
+### Implementation
+- Follow PEP 8.
+- Prefer clear naming and small focused functions.
+- Catch specific exceptions and return actionable failure context.
+- Avoid introducing global mutable state.
+
+### Security and Compliance
+- Never commit secrets, credentials, or private keys.
+- Keep dependency additions minimal and justified.
+- Do not add unrelated telemetry or external calls.
+
+## Validation Expectations
+- Run tests before finalizing (`PYTHONPATH=. pytest -q`).
+- Add/update tests for behavior changes under `tests/`.
+- Prefer behavior assertions over implementation-coupled assertions.
+
+## Documentation Expectations
+- Update `README.md` when setup/behavior/output changes.
+- Keep docs concise; link to canonical files instead of duplicating policy text.
+
+## PR Expectations
+Include:
+- what changed,
+- why it changed,
+- validation commands and outcomes,
+- limitations/risks.
+
+## AI Output Quality Checklist
+- [ ] Scope fully addressed.
+- [ ] No unrelated refactors.
+- [ ] Tests passed.
+- [ ] Documentation updated as needed.
+- [ ] No sensitive data introduced.
+- [ ] Assumptions/limitations called out.
+
+
+## Research Traceability
+- See `docs/ai/RESEARCH_NOTES.md` for external guidance summarized for this structure.

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,0 +1,32 @@
+# Repository Skills Policy
+
+This repo currently has no local runtime skills checked in, but this file defines best-practice structure if skills are added.
+
+## Why This Exists
+Skills are useful only for repeated, specialized workflows that benefit from a reusable playbook.
+
+## Standard Location
+- Place each skill at: `.codex/skills/<skill-name>/SKILL.md`
+- Keep assets/scripts within that same skill folder.
+
+## Required Skill Contents
+Each skill should include:
+1. Trigger conditions (when to use it)
+2. Inputs required from the user/context
+3. Step-by-step workflow
+4. Validation commands
+5. Failure handling/fallback path
+6. Output contract (what the agent should return)
+
+## Quality and Safety Rules
+- Must not conflict with `AGENTS.md` or `AI_INSTRUCTIONS.md`.
+- Must avoid secret handling and unsafe destructive actions.
+- Should prefer deterministic checks over network-dependent checks.
+- Should reuse existing scripts/templates where possible.
+
+## Review Checklist
+- [ ] Trigger is specific and non-overlapping.
+- [ ] Steps are reproducible.
+- [ ] Validation is measurable.
+- [ ] Safety constraints are explicit.
+- [ ] References and paths are valid.

--- a/docs/ai/RESEARCH_NOTES.md
+++ b/docs/ai/RESEARCH_NOTES.md
@@ -1,0 +1,28 @@
+# AI/Agent Instruction Structure Research Notes
+
+This note captures external guidance used to restructure repository AI/agent instruction files.
+
+## Sources Reviewed
+- GitHub Docs: **Adding repository instructions for GitHub Copilot**
+- GitHub Docs: **Support for different types of custom instructions**
+- GitHub Docs: **Using custom instructions to improve Copilot outcomes**
+- GitHub Docs: **Best practices for Copilot coding agent task execution**
+
+## Key Takeaways Applied
+1. Keep Copilot instructions concise and high-signal.
+2. Use a layered policy model to avoid duplication and conflicts.
+3. Put operational rules in one canonical file and reference from runtime-specific files.
+4. Define explicit validation commands to improve reproducibility.
+5. Prefer role/profile docs with a fixed section template for hosted agents.
+
+## Structure Adopted in This Repo
+- Canonical operational policy: `AGENTS.md`
+- Cross-runtime engineering policy: `AI_INSTRUCTIONS.md`
+- Copilot adapter: `.github/copilot-instructions.md`
+- Hosted agent profile index: `.github/agents/README.md`
+- Skill extension policy: `SKILLS.md`
+
+## Maintenance Rules
+- Update canonical policy first (`AGENTS.md`) when constraints change.
+- Update adapters next (`.github/*`, `SKILLS.md`) to stay aligned.
+- Keep runtime-specific files short and reference canonical docs.


### PR DESCRIPTION
### Motivation
- Reviewer feedback and inline comments requested clearer, less-duplicative guidance for Copilot, hosted-agent profiles, and repository skill conventions.  
- The goal is to centralize operational rules, separate engineering standards, and provide short runtime-specific adapters so agents behave consistently across runtimes.  
- Add traceability to external guidance so future maintainers can see the rationale behind the structure and validation expectations.  

### Description
- Introduced a canonical operational contract `AGENTS.md` that defines instruction precedence, working agreements, implementation/testing constraints, and done criteria.  
- Added `AI_INSTRUCTIONS.md` as a cross-runtime engineering-standards layer that prescribes design, implementation, validation, and PR expectations.  
- Created concise runtime adapters and profiles: `.github/copilot-instructions.md` (Copilot adapter) and `.github/agents/README.md` (hosted-agent profile guidance), plus a `SKILLS.md` policy for repository-local skills.  
- Added `docs/ai/RESEARCH_NOTES.md` capturing the external sources and key takeaways that influenced the structure and linked the files for traceability.  

### Testing
- Ran the automated test suite with `PYTHONPATH=. pytest -q`, which completed successfully with `9 passed, 4 warnings`.  
- All changes are documentation/governance only and did not alter runtime behavior covered by the tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a38e450ec8330aca491b9deca8356)