### PR TITLE
Add Dependabot and pre-commit lint automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,10 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "deps"
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,4 +19,3 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "deps"
-

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,23 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,4 +20,5 @@ jobs:
           python-version: "3.11"
 
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+        # v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-yaml
+        exclude: ^\.github/workflows/docker(-publish|_test_run)\.yml$
+      - id: end-of-file-fixer
+        exclude: ^\.github/workflows/docker(-publish|_test_run)\.yml$
+      - id: trailing-whitespace
+        exclude: ^\.github/workflows/docker(-publish|_test_run)\.yml$
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.0
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]

--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ stock_advisor/
 ## Contributing
 Contributions to improve and extend this simple stock advisor project are welcome. If you have ideas, bug fixes, or improvements, feel free to submit a pull request.
 
+Before opening a pull request, install and run pre-commit checks locally:
+
+```bash
+pip install pre-commit
+pre-commit install
+pre-commit run --all-files
+```
+
 ## Disclaimer
 This stock advisor is for educational purposes only and should not be used for real investment decisions. It does not guarantee any financial success, and the author is not responsible for any losses incurred while using this program.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "B", "W"]
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*.py" = ["B011"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "lf"


### PR DESCRIPTION
### Motivation
- Add automated dependency updates so GitHub Actions and pip packages are checked regularly.
- Provide a consistent local and CI linting workflow to catch style and hygiene issues early.
- Minimize unrelated churn by scoping exclusions for legacy workflow files while enabling linting for the rest of the codebase.

### Description
- Add `.github/dependabot.yml` to request weekly updates for `github-actions` and `pip` dependencies.
- Add `.github/workflows/pre-commit.yml` to run pre-commit on pushes to `main` and on pull requests using Python 3.11.
- Add `.pre-commit-config.yaml` with core hygiene hooks and Ruff (`astral-sh/ruff-pre-commit`) configured to auto-fix and fail when fixes remain.
- Add `pyproject.toml` with Ruff settings (`line-length=88`, `target-version=py311`), ignore `E501`, and a per-file-ignore for test-specific rule `B011`, and update `README.md` with local pre-commit instructions.

### Testing
- Ran `python -m pip install pre-commit` and then `pre-commit run --all-files`, which completed successfully after auto-fixes.
- Ran the test suite with `PYTHONPATH=. pytest -q`, which passed (9 passed, warnings only).
- Pre-commit and tests were used as the validation steps and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2ae0b176c8330b4894f1e5369896c)