### PR TITLE
Pin pre-commit GitHub Action to immutable commit SHA

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,4 +20,5 @@ jobs:
           python-version: "3.11"
 
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+        # v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd


### PR DESCRIPTION
### Motivation
- Address a security review comment to avoid using a mutable action tag and ensure CI cannot be changed by retargeting the `pre-commit/action@v3.0.1` tag.

### Description
- Update `.github/workflows/pre-commit.yml` to replace `pre-commit/action@v3.0.1` with the full commit SHA `2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd` and keep an inline comment noting the tag.

### Testing
- Verified the tag resolves to the SHA with `git ls-remote`, ran the test suite with `PYTHONPATH=. pytest -q` which passed (`9 passed`), and attempted `pre-commit run --files .github/workflows/pre-commit.yml` but it was skipped in this environment because `pre-commit` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2d98cc16c83309a4987b533eac85c)